### PR TITLE
Add log.file.* attributes

### DIFF
--- a/event-stream-processing/src/parser.ecs.svc.ts
+++ b/event-stream-processing/src/parser.ecs.svc.ts
@@ -3,7 +3,7 @@ import {Parser} from './parser.isvc';
 import * as lodash from 'lodash';
 import * as path from 'path';
 import {format as formatUrl} from 'url';
-
+import {expandFileAttributesFromPath} from './shared/expand-file-attributes-from-path';
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 
 function explodeURL(url: URL): any {
@@ -81,6 +81,7 @@ export class ParserEcs implements Parser {
   apply(record: any): void {
     if (!lodash.isNil(lodash.get(record, 'log.file.path'))) {
       lodash.set(record, 'log.file.path', (lodash.get(record, 'log.file.path') as string).replace(/\\/g, '/'));
+      expandFileAttributesFromPath(lodash.get(record, 'log.file.path') as string, lodash.get(record, 'log.file'));
     }
     if (!lodash.isNil(lodash.get(record, 'http.request.line'))) {
       const value = lodash.get(record, 'http.request.line');

--- a/event-stream-processing/src/shared/expand-file-attributes-from-path.test.ts
+++ b/event-stream-processing/src/shared/expand-file-attributes-from-path.test.ts
@@ -1,0 +1,16 @@
+import {expandFileAttributesFromPath} from './expand-file-attributes-from-path';
+
+test('expanded file path attributes', () => {
+  const record = {log: {file: {path: '/some/path/to/a/file.txt'}}};
+  expandFileAttributesFromPath(record.log.file.path, record.log.file);
+  expect(record).toEqual({
+    log: {
+      file: {
+        path: '/some/path/to/a/file.txt',
+        directory: '/some/path/to/a',
+        name: 'file.txt',
+        extension: 'txt',
+      },
+    },
+  });
+});

--- a/event-stream-processing/src/shared/expand-file-attributes-from-path.ts
+++ b/event-stream-processing/src/shared/expand-file-attributes-from-path.ts
@@ -1,0 +1,15 @@
+import * as lodash from 'lodash';
+import * as path from 'path';
+
+export function expandFileAttributesFromPath(filePath:string, targetFileObject: any): any {
+  const fileName = path.basename(filePath);
+  lodash.set(targetFileObject, 'directory', path.dirname(filePath));
+  lodash.set(targetFileObject, 'name', fileName);
+  const indexOfLastDotInFileName = fileName.lastIndexOf('.');
+  if (indexOfLastDotInFileName >0) {
+    const fileExt = fileName.substring(indexOfLastDotInFileName+1).trim();
+    if (fileExt.length>0) {
+      lodash.set(targetFileObject, 'extension', fileName.substring(indexOfLastDotInFileName+1));
+    }
+  }
+}


### PR DESCRIPTION
The additional attributes will help with identify counting records from a specific file and compare against the actual number of lines in that file

Added attributes:
- directory
- name
- extension