### PR TITLE
feat: Add typedoc generation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ event-stream-processing/lib
 terraform/.terraform.lock.hcl
 event-stream-processing/asset/GeoLite2-ASN.mmdb
 event-stream-processing/asset/GeoLite2-City.mmdb
+event-stream-processing/doc/

--- a/event-stream-processing/package-lock.json
+++ b/event-stream-processing/package-lock.json
@@ -4423,6 +4423,42 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true,
+      "optional": true
+    },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6895,6 +6931,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6935,6 +6977,27 @@
       "requires": {
         "p-defer": "^1.0.0"
       }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "marked": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "dev": true
     },
     "maxmind": {
       "version": "4.3.1",
@@ -7053,6 +7116,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -7285,6 +7354,32 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -7727,6 +7822,24 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true,
+      "optional": true
+    },
+    "shiki": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.5.tgz",
+      "integrity": "sha512-XFn+rl3wIowDjzdr5DlHoHgQphXefgUTs2bNp/bZu4WF9gTrTLnKwio3f28VjiFG6Jpip7yQn/p4mMj6OrjrtQ==",
+      "dev": true,
+      "requires": {
+        "json5": "^2.2.0",
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "5.2.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -8239,6 +8352,11 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
+    "typed-path": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/typed-path/-/typed-path-2.2.2.tgz",
+      "integrity": "sha512-hgJX0ABEg4NAmpTrjTAalFaB4o6ptx9+3cZhKmYXeI6g1QdsxD39FodgymNvhZOtNhxe6qXsZk/vENzXD2rgTA=="
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -8247,6 +8365,28 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typedoc": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.4.tgz",
+      "integrity": "sha512-slZQhvD9U0d9KacktYAyuNMMOXJRFNHy+Gd8xY2Qrqq3eTTTv3frv3N4au/cFnab9t3T5WA0Orb6QUjMc+1bDA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.7",
+        "handlebars": "^4.7.7",
+        "lunr": "^2.3.9",
+        "marked": "^2.1.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shiki": "^0.9.3",
+        "typedoc-default-themes": "^0.12.10"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
+      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
+      "dev": true
     },
     "typescript": {
       "version": "4.2.4",
@@ -8258,6 +8398,13 @@
       "version": "0.7.28",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
+    },
+    "uglify-js": {
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.10.tgz",
+      "integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
+      "dev": true,
+      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -8335,6 +8482,23 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -8433,6 +8597,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/event-stream-processing/package.json
+++ b/event-stream-processing/package.json
@@ -25,7 +25,8 @@
     "pack": "npm-run-all mkdirs rm-pack compile build-pack",
     "test": "jest --coverage",
     "deploy": "ts-node src/ops/deploy.ts",
-    "ts-node": "ts-node"
+    "ts-node": "ts-node",
+    "typedoc": "typedoc"
   },
   "author": "Clécio Varjão",
   "license": "Apache-2.0",
@@ -44,6 +45,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.3",
     "ts-node": "^9.1.1",
+    "typedoc": "^0.21.4",
     "typescript": "^4.2.4"
   },
   "dependencies": {
@@ -61,6 +63,7 @@
     "maxmind": "^4.3.1",
     "moment": "^2.29.1",
     "reflect-metadata": "^0.1.13",
+    "typed-path": "^2.2.2",
     "ua-parser-js": "^0.7.28"
   },
   "bundledDependencies": true

--- a/event-stream-processing/src/fingerprint-filter.ts
+++ b/event-stream-processing/src/fingerprint-filter.ts
@@ -20,14 +20,15 @@ export class FingerprintFilter implements Parser {
   matches(record: ecs.Record): boolean {
     return record.event.kind === 'event' &&
       record.event.category === 'web' &&
-      record.event.dataset === 'apache.access';
+      record.event.dataset === 'apache.access' &&
+      !lodash.isNil(record.message);
   }
   apply(record: ecs.Record): void {
     // Hash/fingerprinting event.
     const hasher = crypto.createHash('sha256');
     hasher.update(record.host?.hostname ?? '');
     hasher.update(':');
-    hasher.update(path.basename(record.log.file?.path ?? ''));
+    hasher.update(path.basename(record.log?.file?.path ?? ''));
     hasher.update(':');
     hasher.update(`${record.offset ?? (record.log?.file?.offset ?? -1)}`);
     hasher.update(':');

--- a/event-stream-processing/src/types/event.ts
+++ b/event-stream-processing/src/types/event.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+declare namespace ecs {
+    export type Event = {
+        kind: string;
+        category: string;
+        dataset: string;
+        hash: string;
+        /**
+         * Raw text message of entire event. Used to demonstrate log integrity.
+         * If provided as an object, it will be stringfied.
+         * @see {@link https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-original}
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        original: string | any;
+    }
+}

--- a/event-stream-processing/src/types/host.ts
+++ b/event-stream-processing/src/types/host.ts
@@ -1,0 +1,6 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+declare namespace ecs {
+    export type Host = {
+        hostname: string;
+    }
+}

--- a/event-stream-processing/src/types/log.ts
+++ b/event-stream-processing/src/types/log.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+declare namespace ecs {
+    /**
+     * Details about the event’s logging mechanism or logging transport.
+     * @see {@link https://www.elastic.co/guide/en/ecs/current/ecs-log.html}
+     */
+    export type Log = {
+        file: {
+            /**
+             * [non-ecs] The offset position in bytes where the message started in the log file
+             * @label NON_ECS_NATIVE
+             */
+            offset?: number;
+            /**
+             * Full path to the log file this event came from, including the file name.
+             * It should include the drive letter, when appropriate.
+             * @see {@link https://www.elastic.co/guide/en/ecs/current/ecs-log.html#field-log-file-path}
+             */
+            path: string
+        }
+    }
+}

--- a/event-stream-processing/src/types/record.ts
+++ b/event-stream-processing/src/types/record.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+declare namespace ecs {
+    export type Record = {
+        /**
+         * This is the Elastic Search document _id and it is used for performing upserts which enables deduplication
+         * @see {@link https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html}
+         */
+        _id: string;
+        /**
+         * Date/time when the event originated.
+         * @see {@link https://www.elastic.co/guide/en/ecs/current/ecs-base.html#field-timestamp}
+         */
+        '@timestamp': string;
+        /**
+         * For log events the message field contains the log message, optimized for viewing in a log viewer.
+         * @see {@link https://www.elastic.co/guide/en/ecs/current/ecs-base.html#field-message}
+         */
+        message: string;
+        /**
+         * @deprecated This attribute has moved to {@link Log}
+         */
+        offset?: number;
+        event: Event;
+        log?: Log;
+        host?: Host
+    }
+}

--- a/event-stream-processing/typedoc.json
+++ b/event-stream-processing/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "entryPoints": ["./src"],
+    "out": "doc"
+}


### PR DESCRIPTION
Initial work to address issue #53.

This introduces support for `typedoc` and leverage `typed-path` to support path-based manipulation provided by lodash

TBD:
Should we commit the generated docs? same main branch? another orphan branch for github pages?