### PR TITLE
build(deps): security bump yargs-parser to >=13.1.3 (dep of npm-pack-zip)

### DIFF
--- a/event-stream-processing/package-lock.json
+++ b/event-stream-processing/package-lock.json
@@ -8552,16 +8552,24 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
         "yargs-parser": "^9.0.2"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0"
-      }
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/event-stream-processing/package.json
+++ b/event-stream-processing/package.json
@@ -44,7 +44,8 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.6",
     "ts-node": "^9.1.1",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "yargs-parser": ">=13.1.2"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^1.1.0",


### PR DESCRIPTION
Security flag aroung yargs-parser, used by devDependency npm-pack-zip.

https://github.com/BCDevOps/nr-elasticsearch-stack/security/dependabot/event-stream-processing/package-lock.json/yargs-parser/closed

```
Details
CVE-2020-7608
low severity
Vulnerable versions: >= 6.0.0, < 13.1.2
Patched version: 13.1.2
Affected versions of yargs-parser are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of Object, causing the addition or modification of an existing property that will exist on all objects.
Parsing the argument --foo.__proto__.bar baz' adds a bar property with value baz to all objects. This is only exploitable if attackers have control over the arguments being passed to yargs-parser.

Recommendation
Upgrade to versions 13.1.2, 15.0.1, 18.1.1 or later.
```